### PR TITLE
Add 'platforms' to Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,12 @@ import PackageDescription
 
 let package = Package(
     name: "SwiftUIcon",
+    platforms: [
+        .iOS(.v13),
+        .macOS(.v10_15),
+        .tvOS(.v13),
+        .watchOS(.v6)
+    ],
     products: [
         .library(name: "SwiftUIcon", targets: ["SwiftUIcon"]),
     ],


### PR DESCRIPTION
By doing this, Xcode won't complain about not being able to import SwiftUI in release builds.

Since this framework will be run from a SwiftUI-compatible target anyways, this should not be a problem for people using it in projects with lower version requirements... (I think).